### PR TITLE
Update to build with gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "uuid",
+      "sources": [ "src/uuid.cc" ],
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 , "bugs" :
   { "url" : "http://github.com/postwait/node-libuuid/issues"
   }
-, "main" : "./build/Release/libuuid.node"
+, "main" : "./build/Release/uuid.node"
 , "engines" : { "node" : "0.2 || 0.4 || 0.5 || 0.6" }
 , "licenses" :
   [ { "type" : "BSD" } ]

--- a/src/uuid.cc
+++ b/src/uuid.cc
@@ -38,4 +38,4 @@ init(Handle<Object> target) {
   HandleScope scope;
   libuuid::Initialize(target);
 }
-NODE_MODULE(libuuid, init)
+NODE_MODULE(uuid, init)


### PR DESCRIPTION
Add the binding.gyp so that it can compile with new versions of Node.js. Also, after finding that it kept stripping off "lib" from "libuuid" in the target_name and building "uuid.node", I just changed the target_name to uuid and updated package.join to point to that for main.
