### PR TITLE
Use NAN for wider engine support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,38 +1,27 @@
 {
-    'conditions': [
-        ['OS=="solaris"', {
-            'targets': [
-                {
-                    'target_name': 'uuid',
-                    'sources': [ 'src/uuid.cc' ],
+    'targets': [
+        {
+            'target_name': 'uuid',
+            'sources': [ 'src/uuid.cc' ],
+            'include_dirs': [
+                '<!(node -e "require(\'nan\')")'
+            ],
+            'conditions': [
+                ['OS=="solaris"', {
                     'libraries': [ '-luuid' ],
                     'conditions': [
                         ['target_arch=="ia32"', {
-                             'ldflags': [ '-L/opt/omni/lib -R/opt/omni/lib' ]
+                            'ldflags': [ '-L/opt/omni/lib -R/opt/omni/lib' ]
                         }],
                         ['target_arch=="x64"', {
-                             'ldflags': [ '-L/opt/omni/lib/amd64 -R/opt/omni/lib/amd64' ]
+                            'ldflags': [ '-L/opt/omni/lib/amd64 -R/opt/omni/lib/amd64' ]
                         }]
-                     ]
-                }
+                    ]
+                }],
+                ['OS=="linux"', {
+                    'libraries': [ '-luuid' ]
+                }]
             ]
-        }],
-        ['OS=="linux"', {
-            'targets': [
-                {
-                    'target_name': 'uuid',
-                    'sources': [ 'src/uuid.cc' ],
-                    'libraries': [ '-luuid' ],
-                }
-            ]
-        }],
-        ['OS=="mac"', {
-            'targets': [
-                {
-                    'target_name': 'uuid',
-                    'sources': [ 'src/uuid.cc' ]
-                }
-            ]
-        }]
+        }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
   { "type" : "git"
   , "url" : "git://github.com/postwait/node-libuuid.git"
   }
+, "dependencies" : { "nan" : "1.8.4" }
 , "bugs" :
   { "url" : "http://github.com/postwait/node-libuuid/issues"
   }
 , "main" : "./build/Release/uuid.node"
-, "engines" : { "node" : "0.2 || 0.4 || 0.5 || 0.6 || 0.8 || 0.10" }
+, "engines" : { "node" : "0.2 || 0.4 || 0.5 || 0.6 || 0.8 || 0.10 || 0.12" }
 , "licenses" :
   [ { "type" : "BSD" } ]
 , "scripts" : { "test" : "node test/t1.js"}

--- a/src/uuid.cc
+++ b/src/uuid.cc
@@ -1,9 +1,8 @@
 #include <v8.h>
 #include <node.h>
-#include <node_object_wrap.h>
-#include <assert.h>
+#include <nan.h>
 #include <uuid/uuid.h>
-#include <ctype.h>
+
 #undef UUID_STR_LEN
 #define UUID_STR_LEN 36
 static inline void my_uuid_unparse_lower(uuid_t in, char *out) {
@@ -15,35 +14,21 @@ static inline void my_uuid_unparse_lower(uuid_t in, char *out) {
 using namespace v8;
 using namespace node;
 
-class libuuid {
-  public:
-    static void
-    Initialize(v8::Handle<v8::Object> target) {
-      Local<FunctionTemplate> t = FunctionTemplate::New(libuuid::Create);
-      t->InstanceTemplate()->SetInternalFieldCount(1);
+NAN_METHOD(Create) {
+  NanScope();
 
-      target->Set(String::NewSymbol("create"), t->GetFunction());
-    }
+  uuid_t id;
+  char uuid_str[37];
+
+  uuid_generate(id);
+  my_uuid_unparse_lower(id, uuid_str);
+
+  NanReturnValue(NanNew<String>(uuid_str));
+}
 
 
-  protected:
-    static Handle<Value> Create(const Arguments& args) {
-      uuid_t id;
-      HandleScope scope;
-      char uuid_str[37];
-      uuid_generate(id);
-
-      my_uuid_unparse_lower(id, uuid_str);
-      String::New(uuid_str);
-
-      return scope.Close(String::New(uuid_str));
-    }
-
-};
-
-extern "C" void
-init(Handle<Object> target) {
-  HandleScope scope;
-  libuuid::Initialize(target);
+void init(Handle<Object> exports) {
+  exports->Set(NanNew<String>("create"),
+    NanNew<FunctionTemplate>(Create)->GetFunction());
 }
 NODE_MODULE(uuid, init)


### PR DESCRIPTION
I ran test builds on Linux, OSX and SmartOS.
When running in a tight loop, there didn't appear to be any memory leaks.