### PR TITLE
Update NaN dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   { "type" : "git"
   , "url" : "git://github.com/postwait/node-libuuid.git"
   }
-, "dependencies" : { "nan" : "1.8.4" }
+, "dependencies" : { "nan" : "2.3.5" }
 , "bugs" :
   { "url" : "http://github.com/postwait/node-libuuid/issues"
   }

--- a/src/uuid.cc
+++ b/src/uuid.cc
@@ -1,7 +1,5 @@
 #include <uuid/uuid.h>
-#include <node.h>
-#include <v8.h>
-#include <ctype.h>
+#include <nan.h>
 
 #undef UUID_STR_LEN
 #define UUID_STR_LEN 36
@@ -11,22 +9,24 @@ static inline void my_uuid_unparse_lower(uuid_t in, char *out) {
   for(i=0;i<36;i++) out[i] = tolower(out[i]);
 }
 
-using namespace v8;
-using namespace node;
+using v8::FunctionTemplate;
+using v8::String;
+using Nan::GetFunction;
+using Nan::New;
+using Nan::Set;
 
-void CreateUuid(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
+NAN_METHOD(CreateUuid) {
   uuid_t id;
   char uuid_str[37];
 
   uuid_generate(id);
   my_uuid_unparse_lower(id, uuid_str);
 
-  args.GetReturnValue().Set(String::NewFromUtf8(isolate, uuid_str));
+  info.GetReturnValue().Set(New<String>(uuid_str).ToLocalChecked());
 }
 
-
-void init(Local<Object> exports) {
-  NODE_SET_METHOD(exports, "create", CreateUuid);
+NAN_MODULE_INIT(init) {
+  Set(target, New<String>("create").ToLocalChecked(),
+    GetFunction(New<FunctionTemplate>(CreateUuid)).ToLocalChecked());
 }
 NODE_MODULE(uuid, init)


### PR DESCRIPTION
With the change introduced in v0.2.0, it is no longer possible to install node-libuuid on node.js v0.10.x.
I've updated the NaN dependency and returned the module to use that macro syntax.
The code successfully installs and runs on the following combinations of platform and node.js version:

SunOS (SmartOS):
- v0.10.46
- v0.12.15
- v4.4.6
- v5.12.0

Linux (Ubuntu 14.04 runtime):
- v0.10.46
- v0.12.15
- v4.4.6
- v5.12.0

OSX (10.9.5)
- v0.10.46
- v0.12.15
- v4.4.6
- v5.12.0

If there's additional testing or verification you wish to be performed, I'm happy to take a look.
Thanks

-Patrick

CC: @trentm 